### PR TITLE
Add repository_dispatch trigger for agent snapshots

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,6 +9,8 @@
 name: Build
 
 on:
+  repository_dispatch:
+    types: [agent-snapshots-deployed]
   push:
   pull_request:
     types: [ opened, synchronize, reopened ]


### PR DESCRIPTION
This pull request introduces a small update to the GitHub Actions workflow configuration. The workflow will now also be triggered by a `repository_dispatch` event of type `agent-snapshots-deployed`, in addition to the existing triggers.

* GitHub Actions configuration: Updated `.github/workflows/maven.yml` to trigger the workflow on `repository_dispatch` events with type `agent-snapshots-deployed`.