### PR TITLE
Fix Build

### DIFF
--- a/src/test/java/com/embabel/impromptu/TestDataHelper.java
+++ b/src/test/java/com/embabel/impromptu/TestDataHelper.java
@@ -235,7 +235,7 @@ public class TestDataHelper {
      */
     public long countComposers() {
         return persistenceManager.getOne(
-                QuerySpecification.withStatement("MATCH (c:Composer) RETURN count(c)")
+                QuerySpecification.withStatement("MATCH (c:Composer) WHERE c.primarySource = 'test' RETURN count(c)")
                         .transform(Long.class)
         );
     }
@@ -245,7 +245,7 @@ public class TestDataHelper {
      */
     public long countWorks() {
         return persistenceManager.getOne(
-                QuerySpecification.withStatement("MATCH (w:Work) RETURN count(w)")
+                QuerySpecification.withStatement("MATCH (w:Work) WHERE w.primarySource = 'test' RETURN count(w)")
                         .transform(Long.class)
         );
     }

--- a/src/test/java/com/embabel/impromptu/TestLlmConfiguration.java
+++ b/src/test/java/com/embabel/impromptu/TestLlmConfiguration.java
@@ -128,23 +128,8 @@ public class TestLlmConfiguration {
         }
 
         @Override
-        public float[] embed(String text) {
-            return new float[1536];
-        }
-
-        @Override
         public float[] embed(Document document) {
             return new float[1536];
-        }
-
-        @Override
-        public List<float[]> embed(List<String> texts) {
-            return texts.stream().map(t -> new float[1536]).toList();
-        }
-
-        @Override
-        public EmbeddingResponse embedForResponse(List<String> texts) {
-            return new EmbeddingResponse(List.of());
         }
 
         @Override
@@ -157,7 +142,6 @@ public class TestLlmConfiguration {
      * A simple fake EmbeddingService for tests.
      */
     static class FakeEmbeddingService implements EmbeddingService {
-        private final FakeEmbeddingModel model = new FakeEmbeddingModel();
 
         @Override
         public String getName() {
@@ -185,11 +169,6 @@ public class TestLlmConfiguration {
         @Override
         public int getDimensions() {
             return 1536;
-        }
-
-        @Override
-        public Object getModel() {
-            return model;
         }
     }
 

--- a/src/test/java/com/embabel/impromptu/integrations/youtube/YouTubePerformancePersistenceIntegrationTest.java
+++ b/src/test/java/com/embabel/impromptu/integrations/youtube/YouTubePerformancePersistenceIntegrationTest.java
@@ -65,7 +65,7 @@ class YouTubePerformancePersistenceIntegrationTest {
     private NamedEntityDataRepository namedEntityDataRepository;
 
     private static final String TEST_VIDEO_ID = "dQw4w9WgXcQ";
-    private static final String TEST_PERFORMANCE_ID = TEST_VIDEO_ID;
+    private static final String TEST_PERFORMANCE_ID = "perf-" + TEST_VIDEO_ID;
     private static final String TEST_WORK_ID = "work-brahms-symphony4";
 
     @BeforeEach
@@ -123,7 +123,7 @@ class YouTubePerformancePersistenceIntegrationTest {
                             perf.performer = $performer,
                             perf.ensemble = $ensemble,
                             perf.conductor = $conductor,
-                            perf.primarySource = 'youtube-test'
+                            perf.primarySource = $primarySource
                         """)
                         .bind(Map.of(
                                 "id", TEST_PERFORMANCE_ID,
@@ -132,7 +132,8 @@ class YouTubePerformancePersistenceIntegrationTest {
                                 "videoId", TEST_VIDEO_ID,
                                 "performer", "",
                                 "ensemble", "Berlin Philharmonic",
-                                "conductor", "Herbert von Karajan"
+                                "conductor", "Herbert von Karajan",
+                                "primarySource", "youtube-test"
                         ))
         );
 


### PR DESCRIPTION
This pull request updates test helper methods and test data setup to improve test isolation and accuracy, particularly by ensuring that test queries and data are clearly separated from production data. The changes also simplify some test double implementations.

Test query isolation:

* Updated `countComposers()` and `countWorks()` in `TestDataHelper.java` to count only test data by adding a `WHERE` clause filtering on `primarySource = 'test'`. [[1]](diffhunk://#diff-2b516d2e9825a97baae06407710af1cf0dfd72452ec37c46b7735d9f2e29d96dL238-R238) [[2]](diffhunk://#diff-2b516d2e9825a97baae06407710af1cf0dfd72452ec37c46b7735d9f2e29d96dL248-R248)

Test data setup improvements:

* Changed `TEST_PERFORMANCE_ID` in `YouTubePerformancePersistenceIntegrationTest.java` to use a prefix for clearer test identification.
* Modified test data creation in `YouTubePerformancePersistenceIntegrationTest.java` to set `primarySource` using a parameter, and updated the data map accordingly for flexibility and clarity. [[1]](diffhunk://#diff-2996027e2a359d5585fb748572790487047806606428852ec4f7705ebb173753L126-R126) [[2]](diffhunk://#diff-2996027e2a359d5585fb748572790487047806606428852ec4f7705ebb173753L135-R136)

Test double simplification:

* Removed unused or redundant methods from the `FakeEmbeddingService` and its model in `TestLlmConfiguration.java` to streamline the test implementation. [[1]](diffhunk://#diff-aded83e57b2f883928221276b09b5af1e3dfa8a07cb575f091bc7d8ad97cac55L130-L149) [[2]](diffhunk://#diff-aded83e57b2f883928221276b09b5af1e3dfa8a07cb575f091bc7d8ad97cac55L160) [[3]](diffhunk://#diff-aded83e57b2f883928221276b09b5af1e3dfa8a07cb575f091bc7d8ad97cac55L189-L193)