### PR TITLE
Upgrade Embabel Agent to 0.4.0-SNAP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <java.version>21</java.version>
-        <embabel-agent.version>0.3.5-SNAPSHOT</embabel-agent.version>
+        <embabel-agent.version>0.4.0-SNAPSHOT</embabel-agent.version>
         <dice.version>0.1.0-SNAPSHOT</dice.version>
         <vaadin.version>24.6.4</vaadin.version>
         <spotless-maven-plugin.version>2.35.0</spotless-maven-plugin.version>


### PR DESCRIPTION
This pull request updates the `embabel-agent` dependency version in the `pom.xml` file. The version is incremented from `0.3.5-SNAPSHOT` to `0.4.0-SNAPSHOT` to bring in the latest changes or fixes from that library. No other code changes are included.